### PR TITLE
improved contacts fetch time in ios by reducing fields requested

### DIFF
--- a/ios/Classes/Contact.swift
+++ b/ios/Classes/Contact.swift
@@ -47,6 +47,10 @@ struct Contact {
             from: c,
             style: CNContactFormatterStyle.fullName
         ) ?? ""
+        
+        if c.isKeyAvailable(CNContactPhoneNumbersKey) {
+            phones = c.phoneNumbers.map { Phone(fromPhone: $0) }
+        }
 
         // Hack/shortcut: if this key is available, all others are too. (We could have
         // CNContactGivenNameKey instead but it seems to be included by default along

--- a/ios/Classes/SwiftFlutterContactsPlugin.swift
+++ b/ios/Classes/SwiftFlutterContactsPlugin.swift
@@ -23,37 +23,37 @@ public enum FlutterContacts {
         ]
         if withProperties {
             keys += [
-                CNContactGivenNameKey,
-                CNContactFamilyNameKey,
-                CNContactMiddleNameKey,
-                CNContactNamePrefixKey,
-                CNContactNameSuffixKey,
-                CNContactNicknameKey,
-                CNContactPhoneticGivenNameKey,
-                CNContactPhoneticFamilyNameKey,
-                CNContactPhoneticMiddleNameKey,
+//                CNContactGivenNameKey,
+//                CNContactFamilyNameKey,
+//                CNContactMiddleNameKey,
+//                CNContactNamePrefixKey,
+//                CNContactNameSuffixKey,
+//                CNContactNicknameKey,
+//                CNContactPhoneticGivenNameKey,
+//                CNContactPhoneticFamilyNameKey,
+//                CNContactPhoneticMiddleNameKey,
                 CNContactPhoneNumbersKey,
-                CNContactEmailAddressesKey,
-                CNContactPostalAddressesKey,
-                CNContactOrganizationNameKey,
-                CNContactJobTitleKey,
-                CNContactDepartmentNameKey,
-                CNContactUrlAddressesKey,
-                CNContactSocialProfilesKey,
-                CNContactInstantMessageAddressesKey,
-                CNContactBirthdayKey,
-                CNContactDatesKey,
+//                CNContactEmailAddressesKey,
+//                CNContactPostalAddressesKey,
+//                CNContactOrganizationNameKey,
+//                CNContactJobTitleKey,
+//                CNContactDepartmentNameKey,
+//                CNContactUrlAddressesKey,
+//                CNContactSocialProfilesKey,
+//                CNContactInstantMessageAddressesKey,
+//                CNContactBirthdayKey,
+//                CNContactDatesKey,
             ]
             if #available(iOS 10, *) {
-                keys.append(CNContactPhoneticOrganizationNameKey)
+//                keys.append(CNContactPhoneticOrganizationNameKey)
             }
             // Notes need explicit entitlement from Apple starting with iOS13.
             // https://stackoverflow.com/questions/57442114/ios-13-cncontacts-no-longer-working-to-retrieve-all-contacts
             if #available(iOS 13, *), !includeNotesOnIos13AndAbove {} else {
-                keys.append(CNContactNoteKey)
+//                keys.append(CNContactNoteKey)
             }
             if externalIntent {
-                keys.append(CNContactViewController.descriptorForRequiredKeys())
+//                keys.append(CNContactViewController.descriptorForRequiredKeys())
             }
         }
         if withThumbnail { keys.append(CNContactThumbnailImageDataKey) }


### PR DESCRIPTION
- Removed keys from iOS contacts request that we were not using currently
- This helps in significant time reduction in fetching the contacts (50-60%)
- We have looked for paginated fetching, but iOS doesn't provide it out of the box