### PR TITLE
fix(ios): Disabled pagination when pageSize is 0

### DIFF
--- a/ios/Classes/SwiftFlutterContactsPlugin.swift
+++ b/ios/Classes/SwiftFlutterContactsPlugin.swift
@@ -145,8 +145,13 @@ public enum FlutterContacts {
             filteredContacts = cachedContacts
         }
 
-        let offset = page * pageSize
-        let paginatedContacts = filteredContacts.dropFirst(offset).prefix(pageSize)
+        var paginatedContacts: [CNContact] = []
+        if(pageSize > 0){
+            let offset = page * pageSize
+            paginatedContacts = Array(filteredContacts.dropFirst(offset).prefix(pageSize))
+        } else {
+            paginatedContacts = filteredContacts;
+        }
 
         var contacts = paginatedContacts.map { Contact(fromContact: $0) }
 


### PR DESCRIPTION
With pageSize param as null, provided to iOS platform end, it assumed pageSize to be 0. Pagination failed there. Now disabled pagination if pageSize is zero, which is expected behaviour.